### PR TITLE
feat: startup reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7] - 2021-10-24
+### Added
+- VS Code setting to remind on startup. Only checks setting on VS Code startup. See README for instructions on the dailyNovena.remindOnStartup setting.
+
+### Fixed
+- Correctly setting log level based on user setting.
+
 ## [0.0.6] - 2021-10-22
-### Added 
+### Added
 - VS Code setting to change log level. Only checks setting on VS Code startup.
 
 ### Changed
@@ -37,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Not published.
 
-[Unreleased]: https://github.com/joeyhage/daily-novena/compare/v0.0.6...HEAD
+[Unreleased]: https://github.com/joeyhage/daily-novena/compare/v0.0.7...HEAD
+[0.0.6]: https://github.com/joeyhage/daily-novena/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/joeyhage/daily-novena/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/joeyhage/daily-novena/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/joeyhage/daily-novena/compare/v0.0.3...v0.0.4

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pray Novenas from [PrayMoreNovenas.com](https://www.praymorenovenas.com). Not af
 
 ### Using Command Palette (CMD/CTRL + Shift + P)
 
-- `Novena: Pray`: Display prayer for current Novena and day
+- `Novena: Pray`: Display prayer for current Novena and day. This also increments the current day by one. For example, if you are praying day one of the St. Therese of Lisieux Novena, it will change it to day two of the St. Therese of Lisieux Novena.
 - `Novena: Choose`: Choose a Novena to pray. Choosing "Community Novena" will automatically choose the current Novena and day the PrayMoreNovenas community is praying.
 - `Novena: Change day`: Change day of the current Novena to pray.
 
@@ -28,6 +28,10 @@ Pray Novenas from [PrayMoreNovenas.com](https://www.praymorenovenas.com). Not af
 ### Extension Settings
 
 These settings are specific to VS Code and need to be set in the VS Code settings file. See the [documentation](https://code.visualstudio.com/docs/getstarted/settings) for how to do that.
+
+### dailyNovena.remindOnStartup (default: `true`)
+
+Each time VS Code starts, check to see if you have prayed yet for the day. If not, ask you if you would like to continue the current Novena.
 
 #### dailyNovena.logLevel (default: `error`)
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,20 @@
     "configuration": {
       "title": "Daily Novena",
       "properties": {
+        "dailyNovena.remindOnStartup": {
+          "type": "boolean",
+          "scope": "application",
+          "description": "If you haven't prayed yet on a given day, remind you to pray when VS Code starts",
+          "enum": [
+            true,
+            false
+          ],
+          "default": true,
+          "enumDescriptions": [
+            "Please remind me",
+            "Please don't remind me"
+          ]
+        },
         "dailyNovena.logLevel": {
           "type": "string",
           "scope": "application",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,5 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-import commands from "./commands";
+import commands, { pray } from "./commands";
 import { ExtensionConfig } from "./config";
 import { CONFIG_STORAGE_KEY } from "./constants";
 import { log, LogLevel } from "./logger";
@@ -11,10 +9,30 @@ export async function activate(context: vscode.ExtensionContext) {
     log(LogLevel.always, "Running in development mode. Clearing global state.");
     context.globalState.update(CONFIG_STORAGE_KEY, undefined);
   }
-  const extensionConfig = new ExtensionConfig(context.globalState);
+  const extensionConfig = await ExtensionConfig.init(context.globalState);
   context.subscriptions.push(
     ...commands.map((command) => command(extensionConfig))
   );
+  await remindOnStartup(extensionConfig);
 }
 
 export function deactivate() {}
+
+async function remindOnStartup(
+  extensionConfig: ExtensionConfig
+): Promise<void> {
+  const config = extensionConfig.get();
+  if (
+    Boolean(ExtensionConfig.getWorkspaceConfiguration("remindOnStartup")) &&
+    config.lastPrayed?.toDateString() !== new Date().toDateString()
+  ) {
+    const items = ["Yes", "No"];
+    const chosen = await vscode.window.showInformationMessage(
+      "Would you like to pray?",
+      ...items
+    );
+    if (chosen === items[0]) {
+      pray(extensionConfig);
+    }
+  }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
<!-- Try to make the PR title to follow https://www.conventionalcommits.org/en/v1.0.0/ -->

# Summary
Setting to get reminders on vs code startup.
<!-- What are you changing -->

## Context
`dailyNovena.remindOnStartup` can be set to `true` or `false` so you can get reminded if you haven't prayed yet on a given day. See [dailyNovena.remindOnStartup](/joeyhage/daily-novena/blob/main/README.md#dailynovenaremindonstartup-default-true) for instructions.
<!-- Why are you changing it? -->
